### PR TITLE
Add find by keys

### DIFF
--- a/include/simhash.h
+++ b/include/simhash.h
@@ -58,6 +58,7 @@ namespace Simhash {
      * Compute the simhash of a vector of hashes.
      */
     hash_t compute(const std::vector<hash_t>& hashes);
+    hash_t compute(const std::vector<hash_t>& keys);
 
     /**
      * Find the set of all matches within the provided vector of hashes.
@@ -66,6 +67,10 @@ namespace Simhash {
      * restored to their original state.
      */
     matches_t find_all(std::unordered_set<hash_t>& hashes,
+                       size_t number_of_blocks,
+                       size_t different_bits);
+    matches_t find_all_keys(std::unordered_set<hash_t>& hashes,
+                       std::unordered_set<hash_t>& keys,
                        size_t number_of_blocks,
                        size_t different_bits);
 

--- a/src/simhash.cpp
+++ b/src/simhash.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <list>
 
-
 size_t Simhash::num_differing_bits(Simhash::hash_t a, Simhash::hash_t b)
 {
     size_t count(0);
@@ -81,7 +80,6 @@ Simhash::matches_t Simhash::find_all(
             Simhash::hash_t prefix = (*start) & mask;
             std::vector<Simhash::hash_t>::iterator end = start;
             for (; end != copy.end() && (*end & mask) == prefix; ++end) { }
-
             // For all the hashes that are between start and end, consider them all
             for (auto a = start; a != end; ++a)
             {
@@ -165,7 +163,6 @@ Simhash::matches_t Simhash::find_all_keys(
             start = end;
         }
     }
-
 
     return results;
 }

--- a/src/simhash.cpp
+++ b/src/simhash.cpp
@@ -3,8 +3,7 @@
 
 #include <algorithm>
 #include <list>
-#include <iostream>
-#include <cstdint>
+
 
 size_t Simhash::num_differing_bits(Simhash::hash_t a, Simhash::hash_t b)
 {
@@ -45,14 +44,6 @@ Simhash::hash_t Simhash::compute(const std::vector<Simhash::hash_t>& hashes)
     return result;
 }
 
-void print(std::unordered_set<Simhash::hash_t> const &s)
-{
-    // Helper function to print values
-    for (auto const &i: s) {
-        std::cout << i << "\n";
-    }
-}
-
 /**
  * Find all near-matches in a set of hashes.
  *
@@ -80,9 +71,7 @@ Simhash::matches_t Simhash::find_all(
         };
         std::transform(hashes.begin(), hashes.end(), copy.begin(), op);
         std::sort(copy.begin(), copy.end());
-        // std::cout << "*******************************************************";
-        // std::cout << "\n Starting new permutation \n";
-        // std::cout << "*******************************************************";
+
         // Walk through and find regions that have the same prefix subject to the mask
         Simhash::hash_t mask = permutation.search_mask();
         auto start = copy.begin();
@@ -92,20 +81,14 @@ Simhash::matches_t Simhash::find_all(
             Simhash::hash_t prefix = (*start) & mask;
             std::vector<Simhash::hash_t>::iterator end = start;
             for (; end != copy.end() && (*end & mask) == prefix; ++end) { }
-            // std::cout << "\n end: \n";
-            // std::cout << *end;
+
             // For all the hashes that are between start and end, consider them all
             for (auto a = start; a != end; ++a)
             {
                 for (auto b = a + 1; b != end; ++b)
                 {
-                    // std::cout << "\nComparing a:b \n";
-                    // std::cout << *a;
-                    // std::cout << " : ";
-                    // std::cout << *b;
                     if (Simhash::num_differing_bits(*a, *b) <= different_bits)
                     {
-                        // std::cout << "\nFound match \n";
                         Simhash::hash_t a_raw = permutation.reverse(*a);
                         Simhash::hash_t b_raw = permutation.reverse(*b);
                         // Insert the result keyed on the smaller of the two
@@ -114,7 +97,6 @@ Simhash::matches_t Simhash::find_all(
                                 std::min(a_raw, b_raw),
                                 std::max(a_raw, b_raw)));
                     }
-                    // std::cout << "\n -------------------";
                 }
             }
 
@@ -135,12 +117,6 @@ Simhash::matches_t Simhash::find_all_keys(
     // Copy the values of hashes and keys:
     std::vector<Simhash::hash_t> copy(hashes.begin(), hashes.end());
     std::vector<Simhash::hash_t> copy_keys(keys.begin(), keys.end());
-    // Ad-hoc printing:
-    // std::cout << "The hashes are: \n";
-    // print(hashes);
-    // std::cout << "The keys are: \n";
-    // print(keys);
-    // std::cout << "\n -------------------";
 
     // Create new container:
     Simhash::matches_t results;
@@ -148,13 +124,12 @@ Simhash::matches_t Simhash::find_all_keys(
     // Iterate over each permutation:
     for (Simhash::Permutation& permutation : permutations)
     {
-        // Apply the permutation to the set of hashes and sort
+        // Apply the permutation to the set of hashes and keys and sort
         auto op = [permutation](Simhash::hash_t h) -> Simhash::hash_t {
             return permutation.apply(h);
         };
         std::transform(hashes.begin(), hashes.end(), copy.begin(), op);
         std::sort(copy.begin(), copy.end());
-        // Sort keys too:
         std::transform(keys.begin(), keys.end(), copy_keys.begin(), op);
         std::sort(copy_keys.begin(), copy_keys.end());
 
@@ -168,16 +143,11 @@ Simhash::matches_t Simhash::find_all_keys(
             Simhash::hash_t prefix = (*start) & mask;
             std::vector<Simhash::hash_t>::iterator end = start;
             for (; end != copy.end() && (*end & mask) == prefix; ++end) { }
-            // For all the hashes that are between start and end, consider them all
+            // For all the hashes that are between start and end, compare to each key
             for (auto a = start; a != end; ++a)
             {
                 for (auto key : copy_keys)
-                // for (auto key = copy_keys.begin(); key != copy_keys.end(); ++key)
                 {
-                    // std::cout << "\nComparing a:key \n";
-                    // std::cout << *a;
-                    // std::cout << " : ";
-                    // std::cout << key;
                     if (Simhash::num_differing_bits(*a, key) <= different_bits)
                     {
                         Simhash::hash_t a_raw = permutation.reverse(*a);


### PR DESCRIPTION
Adds a new function `Simhash::find_all_keys` which allows finding the matches between some keys in hashes.